### PR TITLE
Add changes to convert stream to byte array without saving file

### DIFF
--- a/upload-service/convertByteArrayStreamToString.bal
+++ b/upload-service/convertByteArrayStreamToString.bal
@@ -1,0 +1,36 @@
+import ballerina/mime;
+import ballerina/io;
+
+
+function convertByteArrayStreamToString(stream<byte[], io:Error?> streamer) returns string|error {
+
+        string returnString = "";
+
+        while true {
+            
+            record {|byte[] value;|}|io:Error? nextByteArray = streamer.next();
+
+            if nextByteArray is record {|byte[] value;|} {
+
+                string|byte[]|io:ReadableByteChannel|mime:EncodeError base64EncodeByteArray = mime:base64Encode(nextByteArray.value);
+                if base64EncodeByteArray is string {
+                    return error("Custom Error --> Invalid input: Expected 'byte[]', found 'string'");
+                } else if base64EncodeByteArray is byte[] {
+                    // Actual code we need to run (All else are error handling. Need to find better way to do later.)
+                    string base64EncodedString = check string:fromBytes(base64EncodeByteArray);
+                    returnString = returnString.concat(base64EncodedString);
+
+                } else if base64EncodeByteArray is io:ReadableByteChannel {
+                    return error("Custom Error --> Invalid input: Expected 'byte[]', found 'io:ReadableByteChannel'");
+                } else {
+                    return error("Custom Error --> Invalid input: Expected 'byte[]', found nothing");
+                }
+                
+            } else {
+
+                break;
+            }
+        }
+
+        return returnString;
+    }

--- a/upload-service/service.bal
+++ b/upload-service/service.bal
@@ -67,10 +67,8 @@ service / on new http:Listener(9090) {
                     fileName = regex:replaceAll(fileNameArray[1], "\"", "");
 
                 }
-                check io:fileWriteBlocksFromStream("./files/"  + fileName + ".zip", streamer);
-                byte[] submissionFile = check io:fileReadBytes("./files/"  + fileName + ".zip");
-                byte[] base64Encoded = <byte[]>(check mime:base64Encode(submissionFile));
-                string base64EncodedString = check string:fromBytes(base64Encoded);
+
+                string base64EncodedString = check convertByteArrayStreamToString(streamer);
 
                 string _ = check redisConn->set(fileName, base64EncodedString);
                 redisConn.stop();
@@ -89,4 +87,6 @@ service / on new http:Listener(9090) {
     
         return "Recieved Submission.";
     }
+
 }
+


### PR DESCRIPTION
Added changes so that temporarily saving the submission file is not needed. Directly convert stream<byte[]> into string that will be saved in the Redis database.